### PR TITLE
bugfix in vegan CRAN release 2.5-6 breaks reduce.matrix

### DIFF
--- a/R/reduce.matrix.R
+++ b/R/reduce.matrix.R
@@ -87,7 +87,7 @@ reduce.matrix <- function(matrix, distance = "gower", by.row = TRUE, verbose = F
     ## Function for selecting which row to remove
     remove.one.by.one <- function(removed, no_na_input, distance) {
         ## Get the distance matrix
-        dist_matrix <- as.matrix(vegan::vegdist(no_na_input[!c(names %in% removed),], method = distance))
+        dist_matrix <- as.matrix(vegan::vegdist(no_na_input[!c(names %in% removed),], method = distance, na.rm = TRUE))
         
         ## Check if there are NAs
         has_NA <<- any(is.na(dist_matrix))


### PR DESCRIPTION
reduce.matrix() assumes that NA values are passed to vegdist,
but documented behaviour is that they are not accepted. Vegan
accepted these from version 2.5-1, and this bug was fixed in
2.5-6, but reduce.matrix() assumed the buggy behaviour. This
commit re-instates the old behaviour of reduce.matrix.